### PR TITLE
Handle `Redirect` profile preference

### DIFF
--- a/src/StreamMaster.API/Controllers/VController.cs
+++ b/src/StreamMaster.API/Controllers/VController.cs
@@ -49,16 +49,16 @@ public class VsController(ILogger<VsController> logger, IProfileService profileS
 
             StreamResult streamResult = await videoService.AddClientToChannelAsync(HttpContext, streamGroupId, streamGroupProfileId, smChannelId, cancellationToken);
 
-            if (streamResult.ClientConfiguration == null)
-            {
-                logger.LogWarning("Channel with ChannelId {channelId} not found or failed. Name: {name}", smChannelId, streamResult.ClientConfiguration?.SMChannel.Name ?? "Unknown");
-                return NotFound();
-            }
-
             if (!string.IsNullOrEmpty(streamResult.RedirectUrl))
             {
                 logger.LogInformation("Channel with ChannelId {channelId} is redirecting to {redirectUrl}", smChannelId, streamResult.RedirectUrl);
                 return Redirect(streamResult.RedirectUrl);
+            }
+
+            if (streamResult.ClientConfiguration == null)
+            {
+                logger.LogWarning("Channel with ChannelId {channelId} not found or failed. Name: {name}", smChannelId, streamResult.ClientConfiguration?.SMChannel.Name ?? "Unknown");
+                return NotFound();
             }
 
             // Register client stopped event


### PR DESCRIPTION
## Description

Logic branch was causing early return, when `RedirectUrl` should have been tested first.

### Issues (Fixed or Closed)

- Fixes https://github.com/carlreid/StreamMaster/issues/33

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

1. Create new Stream Group, ->Select "Redirect" as "Command Profile"
2. Add a Channel to the new Stream group
3. Attempt to stream the Channel from the Stream Group's M3U URL
4. 
## Checklist

- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/) naming convention
- [x] My branch is up to date with the `main` branch (rebased)
- [x] My code follows the style guidelines and existing patterns of this project
- [x] I have performed a self-review of my own code
