### PR TITLE
Cache EPG logos

### DIFF
--- a/src/StreamMaster.API/Services/PostStartup.cs
+++ b/src/StreamMaster.API/Services/PostStartup.cs
@@ -57,10 +57,15 @@ public class PostStartup(
 
         while (taskQueue.HasJobs())
         {
-            await Task.Delay(250, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
         }
 
-        //await dataRefreshService.RefreshAll();
+        await taskQueue.CacheEPGChannelLogos(cancellationToken).ConfigureAwait(false);
+
+        while (taskQueue.HasJobs())
+        {
+            await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+        }
 
         await taskQueue.SetIsSystemReady(true, cancellationToken).ConfigureAwait(false);
     }

--- a/src/StreamMaster.Application/Logos/Commands/CacheEPGChannelLogosRequest.cs
+++ b/src/StreamMaster.Application/Logos/Commands/CacheEPGChannelLogosRequest.cs
@@ -1,0 +1,13 @@
+﻿namespace StreamMaster.Application.Logos.Commands
+{
+    public record CacheEPGChannelLogosRequest() : IRequest<DataResponse<bool>>, IBaseRequest;
+
+    public class CacheEPGChannelLogosRequestHandler(ILogoService logoService) : IRequestHandler<CacheEPGChannelLogosRequest, DataResponse<bool>>
+    {
+        public async Task<DataResponse<bool>> Handle(CacheEPGChannelLogosRequest request, CancellationToken cancellationToken)
+        {
+            DataResponse<bool> dataResponse = await logoService.CacheEPGChannelLogosAsync(cancellationToken);
+            return DataResponse.True;
+        }
+    }
+}

--- a/src/StreamMaster.Application/Logos/ILogoInterfaces.cs
+++ b/src/StreamMaster.Application/Logos/ILogoInterfaces.cs
@@ -1,9 +1,12 @@
-﻿
-namespace StreamMaster.Application.Logos;
+﻿namespace StreamMaster.Application.Logos;
 
 public interface ILogoTasks
 {
+    ValueTask CacheEPGChannelLogos(CancellationToken cancellationToken = default);
+
     ValueTask CacheChannelLogos(CancellationToken cancellationToken = default);
+
     ValueTask CacheStreamLogos(CancellationToken cancellationToken = default);
+
     ValueTask ScanForTvLogos(CancellationToken cancellationToken = default);
 }

--- a/src/StreamMaster.Domain/Enums/SMQueCommand.cs
+++ b/src/StreamMaster.Domain/Enums/SMQueCommand.cs
@@ -4,6 +4,7 @@ public enum SMQueCommand
 {
     CacheChannelLogos,
     CacheStreamLogos,
+    CacheEPGChannelLogos,
 
     EPGRemovedExpiredKeys,
     ScanForTvLogos,

--- a/src/StreamMaster.Infrastructure/Services/QueueService/BackgroundTaskQueue.Icons.cs
+++ b/src/StreamMaster.Infrastructure/Services/QueueService/BackgroundTaskQueue.Icons.cs
@@ -10,6 +10,11 @@ public partial class BackgroundTaskQueue : ILogoTasks
         await QueueAsync(SMQueCommand.CacheChannelLogos, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask CacheEPGChannelLogos(CancellationToken cancellationToken = default)
+    {
+        await QueueAsync(SMQueCommand.CacheEPGChannelLogos, cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask CacheStreamLogos(CancellationToken cancellationToken = default)
     {
         await QueueAsync(SMQueCommand.CacheStreamLogos, cancellationToken).ConfigureAwait(false);

--- a/src/StreamMaster.Infrastructure/Services/QueueService/QueuedHostedService.cs
+++ b/src/StreamMaster.Infrastructure/Services/QueueService/QueuedHostedService.cs
@@ -16,6 +16,7 @@ using StreamMaster.Application.SchedulesDirect.Commands;
 using StreamMaster.Application.Services;
 using StreamMaster.Application.Statistics.Commands;
 using StreamMaster.Application.StreamGroups.Commands;
+using StreamMaster.Domain.API;
 using StreamMaster.Domain.Enums;
 
 namespace StreamMaster.Infrastructure.Services.QueueService;
@@ -93,6 +94,10 @@ public sealed class QueuedHostedService(
 
                     case SMQueCommand.CacheStreamLogos:
                         await _sender.Send(new CacheSMStreamLogosRequest(), cancellationSource.Token).ConfigureAwait(false);
+                        break;
+
+                    case SMQueCommand.CacheEPGChannelLogos:
+                        await _sender.Send(new CacheEPGChannelLogosRequest(), cancellationSource.Token).ConfigureAwait(false);
                         break;
 
                     case SMQueCommand.ScanForTvLogos:


### PR DESCRIPTION
## Description

Implements a `CacheEPGChannelLogos` command for caching EPG logos.

### Issues (Fixed or Closed)

- Fixes https://github.com/carlreid/StreamMaster/issues/31

## Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

After auto-assign of EPG, restart StreamMaster where logos will be cached

## Checklist

- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/) naming convention
- [x] My branch is up to date with the `main` branch (rebased)
- [x] My code follows the style guidelines and existing patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented complex logic
- [ ] I have added tests (if applicable)
- [ ] All tests are passing
- [ ] I have updated documentation as needed
