### PR TITLE
Remove extra forward slash

### DIFF
--- a/src/StreamMaster.WebUI/components/icons/IconSelector.tsx
+++ b/src/StreamMaster.WebUI/components/icons/IconSelector.tsx
@@ -75,8 +75,8 @@ const IconSelector: React.FC<IconSelectorProps> = ({
 
 	const itemTemplate = (icon: CustomLogoDto) => {
 		let iconUrl = icon.Source;
-		if (!iconUrl.startsWith("http")) {
-			iconUrl = `${isDev ? `${baseHostURL}` : "/"}${iconUrl}`;
+		if (!iconUrl.startsWith("http") && isDev) {
+			iconUrl = baseHostURL + iconUrl;
 		}
 
 		return (


### PR DESCRIPTION
Remove extra forward slash that prevents tv logos from loading.

## Description

When not running in Dev mode, an extra / is added to the URLs for locally stored tv logos. This prevents them from loading.

### Issues (Fixed or Closed)

- Related to #18

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

- [x] Steps to reproduce/test the changes

1. Run StreamMaster WebUI but not in Dev mode. (npm run builddev)
2. Try to list logos for a channel
3. Without this change, they fail to load. With this change, they load!

## Visual Changes

- [x] Screenshots/videos attached

**Before**
![image](https://github.com/user-attachments/assets/101ed86a-34e0-4ae0-8682-11add7f0a36e)

**After**
![image](https://github.com/user-attachments/assets/4bfa2675-25a0-4afb-bda3-23999217ac54)


## Checklist

- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/) naming convention
- [x] My branch is up to date with the `main` branch (rebased)
- [x] My code follows the style guidelines and existing patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented complex logic
- [x] I have added tests (if applicable)
- [x] All tests are passing
- [x] I have updated documentation as needed
