### PR TITLE
Apply command profile when defined

### DIFF
--- a/src/StreamMaster.Application/EPG/Commands/XMLTVBuilder.cs
+++ b/src/StreamMaster.Application/EPG/Commands/XMLTVBuilder.cs
@@ -82,7 +82,7 @@ public class XMLTVBuilder(
         cancellation.ThrowIfCancellationRequested();
 
         // Process Dummy Configurations
-        List<VideoStreamConfig> dummyVideoStreamConfigs = [.. videoStreamConfigs.Where(a => a.EPGNumber == EPGHelper.DummyId)];
+        List<VideoStreamConfig> dummyVideoStreamConfigs = [.. videoStreamConfigs.Where(a => a.EPGNumber == EPGHelper.UserId)];
         if (dummyVideoStreamConfigs.Count > 0)
         {
             ProcessDummyConfigs(xmlTv, dummyVideoStreamConfigs);
@@ -91,7 +91,7 @@ public class XMLTVBuilder(
         cancellation.ThrowIfCancellationRequested();
 
         // Process Custom PlayList Configurations
-        List<VideoStreamConfig> customVideoStreamConfigs = [.. videoStreamConfigs.Where(a => a.EPGNumber == EPGHelper.CustomPlayListId)];
+        List<VideoStreamConfig> customVideoStreamConfigs = [.. videoStreamConfigs.Where(a => a.EPGNumber == EPGHelper.MovieId)];
         if (customVideoStreamConfigs.Count > 0)
         {
             ProcessCustomPlaylists(xmlTv, customVideoStreamConfigs);

--- a/src/StreamMaster.Application/SMChannels/Queries/GetPagedSMChannelsRequest.cs
+++ b/src/StreamMaster.Application/SMChannels/Queries/GetPagedSMChannelsRequest.cs
@@ -42,7 +42,7 @@ internal class GetPagedSMChannelsRequestHandler(IRepositoryWrapper Repository, I
             await Repository.SMChannelStreamLink.UpdateSMChannelDtoRanks(channel);
             await Repository.SMChannelChannelLink.UpdateSMChannelDtoRanks(channel);
 
-            //SMStreamTypeEnum sType = channel.M3UFileId == EPGHelper.CustomPlayListId ? SMStreamTypeEnum.CustomPlayList : SMStreamTypeEnum.Regular;
+            //SMStreamTypeEnum sType = channel.M3UFileId == EPGHelper.CustomPlayListId ? SMStreamTypeEnum.Movie : SMStreamTypeEnum.Regular;
 
             ////channel.ChannelLogo = channel.ChannelLogo;// logoSerice.GetLogoUrl(channel.ChannelLogo, "", sType);
             channel.SMStreamDtos = [.. channel.SMStreamDtos.OrderBy(a => a.Rank)];

--- a/src/StreamMaster.Application/SMChannels/Queries/GetPagedSMChannelsRequest.cs
+++ b/src/StreamMaster.Application/SMChannels/Queries/GetPagedSMChannelsRequest.cs
@@ -42,7 +42,7 @@ internal class GetPagedSMChannelsRequestHandler(IRepositoryWrapper Repository, I
             await Repository.SMChannelStreamLink.UpdateSMChannelDtoRanks(channel);
             await Repository.SMChannelChannelLink.UpdateSMChannelDtoRanks(channel);
 
-            //SMStreamTypeEnum sType = channel.M3UFileId == EPGHelper.CustomPlayListId ? SMStreamTypeEnum.Movie : SMStreamTypeEnum.Regular;
+            //SMStreamTypeEnum sType = channel.M3UFileId == EPGHelper.MovieId ? SMStreamTypeEnum.Movie : SMStreamTypeEnum.Regular;
 
             ////channel.ChannelLogo = channel.ChannelLogo;// logoSerice.GetLogoUrl(channel.ChannelLogo, "", sType);
             channel.SMStreamDtos = [.. channel.SMStreamDtos.OrderBy(a => a.Rank)];

--- a/src/StreamMaster.Application/StreamGroups/StreamGroupService.cs
+++ b/src/StreamMaster.Application/StreamGroups/StreamGroupService.cs
@@ -591,7 +591,7 @@ public partial class StreamGroupService(IHttpContextAccessor httpContextAccessor
 
             string cleanName = smChannel.Name.ToCleanFileString();
             string logo = logoService.GetLogoUrl(smChannel, baseUrl);
-            string epgId = string.IsNullOrEmpty(smChannel.EPGId) ? EPGHelper.DummyId + "-Dummy" : smChannel.EPGId;
+            string epgId = string.IsNullOrEmpty(smChannel.EPGId) ? EPGHelper.UserId + "-Dummy" : smChannel.EPGId;
 
             StationChannelName? match = cacheManager.StationChannelNames
                 .SelectMany(kvp => kvp.Value)

--- a/src/StreamMaster.Domain/Configuration/CommandProfile.cs
+++ b/src/StreamMaster.Domain/Configuration/CommandProfile.cs
@@ -31,25 +31,25 @@ public class CommandProfileDict : IProfileDict<CommandProfile>
     [JsonIgnore]
     public Dictionary<string, CommandProfile> Profiles => CommandProfiles;
 
-    public bool HasProfile(string CommandProfileName)
+    public bool HasProfile(string commandProfileName)
     {
-        return Profiles.TryGetValue(CommandProfileName, out _);
+        return Profiles.TryGetValue(commandProfileName, out _);
     }
 
-    public CommandProfileDto GetProfileDto(string CommandProfileName)
+    public CommandProfileDto GetProfileDto(string commandProfileName)
     {
-        return GetDefaultProfileDto(CommandProfileName);
+        return GetDefaultProfileDto(commandProfileName);
     }
 
-    public CommandProfileDto GetDefaultProfileDto(string defaultName = "Default")
+    public CommandProfileDto GetDefaultProfileDto(string profileName = "Default")
     {
-        CommandProfile? defaultProfile = GetProfile(defaultName);
-        return defaultProfile == null
-            ? throw new Exception($"Command Profile {defaultName} not found")
-            : GetProfileDtoFromProfile(defaultProfile, defaultName);
+        CommandProfile? commandProfile = GetProfile(profileName);
+        return commandProfile == null
+            ? throw new Exception($"Command Profile {profileName} not found")
+            : GetProfileDtoFromCommandProfile(commandProfile, profileName);
     }
 
-    public static CommandProfileDto GetProfileDtoFromProfile(CommandProfile commandProfile, string ProfileName)
+    public static CommandProfileDto GetProfileDtoFromCommandProfile(CommandProfile commandProfile, string ProfileName)
     {
         return new CommandProfileDto
         {
@@ -68,7 +68,7 @@ public class CommandProfileDict : IProfileDict<CommandProfile>
         {
             if (Profiles.TryGetValue(key, out CommandProfile? profile))
             {
-                ret.Add(GetProfileDtoFromProfile(profile, key));
+                ret.Add(GetProfileDtoFromCommandProfile(profile, key));
             }
         }
         return ret;

--- a/src/StreamMaster.Domain/Dto/LogoInfo.cs
+++ b/src/StreamMaster.Domain/Dto/LogoInfo.cs
@@ -70,7 +70,7 @@ public class LogoInfo
             smStream.Logo,
             smStream.SMStreamType switch
             {
-                SMStreamTypeEnum.CustomPlayList => SMFileTypes.CustomPlayListLogo,
+                SMStreamTypeEnum.Movie => SMFileTypes.CustomPlayListLogo,
                 _ => SMFileTypes.Logo
             })
     {

--- a/src/StreamMaster.Domain/Enums/SMStreamTypeEnum.cs
+++ b/src/StreamMaster.Domain/Enums/SMStreamTypeEnum.cs
@@ -1,10 +1,10 @@
 ﻿namespace StreamMaster.Domain.Enums;
 
 [TsEnum]
-public enum SMChannelTypeEnum
+public enum SMStreamTypeEnum
 {
     Regular = 0,
-    MultiView = 1,
+    User = 1,
     Movie = 2,
     Intro = 3,
     Message = 4,

--- a/src/StreamMaster.Domain/Helpers/EPGHelper.cs
+++ b/src/StreamMaster.Domain/Helpers/EPGHelper.cs
@@ -7,9 +7,9 @@ namespace StreamMaster.Domain.Helpers;
 public partial class EPGHelper() : IEPGHelper
 {
     public const int SchedulesDirectId = -1;
-    public const int DummyId = -2;
-    public const int CustomPlayListId = -3;
-    public const int IntroPlayListId = -4;
+    public const int UserId = -2;
+    public const int MovieId = -3;
+    public const int IntroId = -4;
     public const int MessageId = -5;
 
     public const string EPGMatch = @"(^\-?\d+)-(.*)";
@@ -73,29 +73,6 @@ public partial class EPGHelper() : IEPGHelper
             : ((int epgNumber, string stationId))(epgNumber, matches[0].Groups[2].Value);
     }
 
-    //public bool IsDummy(string? user_tvg_id)
-    //{
-    //    if (string.IsNullOrEmpty(user_tvg_id))
-    //    {
-    //        return true;
-    //    }
-
-    //    if (user_tvg_id.StartsWith($"{DummyId}-"))
-    //    {
-    //        return true;
-    //    }
-
-    //    //
-    //    //bool test = IsValidEPGId(user_tvg_id);
-    //    //return test || Regex.IsMatch(user_tvg_id, setting.DummyRegex, RegexOptions.IgnoreCase) || !string.IsNullOrEmpty(user_tvg_id);
-    //    return false;
-    //}
-
-    //public bool IsDummy(int epgNumber)
-    //{
-    //    return epgNumber == DummyId;
-    //}
-
     public bool IsSchedulesDirect(int epgNumber)
     {
         return epgNumber == SchedulesDirectId;
@@ -107,9 +84,9 @@ public partial class EPGHelper() : IEPGHelper
         return matches.Count > 0;
     }
 
-    public bool IsCustom(int epgNumber)
+    public bool IsMovie(int epgNumber)
     {
-        return epgNumber == CustomPlayListId;
+        return epgNumber == MovieId;
     }
 
     [GeneratedRegex(EPGMatch)]

--- a/src/StreamMaster.Domain/Helpers/EPGNumberStationIdExtension.cs
+++ b/src/StreamMaster.Domain/Helpers/EPGNumberStationIdExtension.cs
@@ -15,7 +15,7 @@ public static partial class EPGNumberStationIdExtension
     {
         if (string.IsNullOrWhiteSpace(userTvgId))
         {
-            return (EPGHelper.DummyId, "Dummy");
+            return (EPGHelper.UserId, "Dummy");
         }
 
         // Define or retrieve your regex here
@@ -27,7 +27,7 @@ public static partial class EPGNumberStationIdExtension
         // Validate the match and parse the values
         if (!match.Success || match.Groups.Count != 3)
         {
-            return (EPGHelper.DummyId, userTvgId);
+            return (EPGHelper.UserId, userTvgId);
         }
 
         if (int.TryParse(match.Groups[1].Value, out int epgNumber))
@@ -36,7 +36,7 @@ public static partial class EPGNumberStationIdExtension
             return (epgNumber, stationId);
         }
 
-        return (EPGHelper.DummyId, "Dummy");
+        return (EPGHelper.UserId, "Dummy");
     }
 
     [GeneratedRegex(EPGHelper.EPGMatch)]

--- a/src/StreamMaster.Domain/Models/VideoStreamConfig.cs
+++ b/src/StreamMaster.Domain/Models/VideoStreamConfig.cs
@@ -78,9 +78,9 @@ public class VideoStreamConfig
     /// </summary>
     public OutputProfileDto? OutputProfile { get; set; }
 
-    public bool IsDummy => M3UFileId == EPGHelper.DummyId;
-    public bool IsCustom => M3UFileId == EPGHelper.CustomPlayListId;
-    public bool IsIntro => M3UFileId == EPGHelper.IntroPlayListId;
+    public bool IsDummy => M3UFileId == EPGHelper.UserId;
+    public bool IsMovie => M3UFileId == EPGHelper.MovieId;
+    public bool IsIntro => M3UFileId == EPGHelper.IntroId;
 
     public string BaseUrl { get; set; } = string.Empty;
 

--- a/src/StreamMaster.Domain/Services/IEPGHelper.cs
+++ b/src/StreamMaster.Domain/Services/IEPGHelper.cs
@@ -2,11 +2,10 @@
 {
     public interface IEPGHelper
     {
-        //bool IsValidEPGId(string epgId);
         (int epgNumber, string stationId) ExtractEPGNumberAndStationId(string epgId);
-        //bool IsDummy(string epgId);
-        //bool IsDummy(int epgNumber);
-        bool IsCustom(int epgNumber);
+
+        bool IsMovie(int epgNumber);
+
         bool IsSchedulesDirect(int epgNumber);
     }
 }

--- a/src/StreamMaster.Infrastructure.EF/Repositories/SMChannelsRepository.cs
+++ b/src/StreamMaster.Infrastructure.EF/Repositories/SMChannelsRepository.cs
@@ -84,14 +84,14 @@ public class SMChannelsRepository(ILogger<SMChannelsRepository> intLogger,
             }
 
             string stationId = smChannel.EPGId;
-            int epgNumber = EPGHelper.DummyId;
+            int epgNumber = EPGHelper.UserId;
 
             if (EPGHelper.IsValidEPGId(smChannel.EPGId))
             {
                 (epgNumber, stationId) = smChannel.EPGId.ExtractEPGNumberAndStationId();
             }
 
-            if (epgNumber < EPGHelper.DummyId)
+            if (epgNumber < EPGHelper.UserId)
             {
                 return;
             }

--- a/src/StreamMaster.Infrastructure/Services/FileUtilService.cs
+++ b/src/StreamMaster.Infrastructure/Services/FileUtilService.cs
@@ -111,10 +111,12 @@ namespace StreamMaster.Infrastructure.Services
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
+                    // Only handle start elements where relevant
                     if (reader.NodeType == XmlNodeType.Element)
                     {
                         if (reader.Name == "programme")
                         {
+                            // Before continue, if we have a channel currently open, add it to the list
                             if (currentChannel is not null)
                             {
                                 // Only add if not a duplicate
@@ -125,7 +127,7 @@ namespace StreamMaster.Infrastructure.Services
                                 }
                                 currentChannel = null;
                             }
-                            break;
+                            continue;
                         }
 
                         if (reader.Name == "channel")

--- a/src/StreamMaster.SchedulesDirect/Converters/DataPreparationService.cs
+++ b/src/StreamMaster.SchedulesDirect/Converters/DataPreparationService.cs
@@ -62,7 +62,7 @@ namespace StreamMaster.SchedulesDirect.Converters
 
             if (service.MxfScheduleEntries.ScheduleEntry.Count == 0 && sdSettings.XmltvAddFillerData)
             {
-                if (service.EPGNumber == EPGHelper.CustomPlayListId)
+                if (service.EPGNumber == EPGHelper.MovieId)
                 {
                     // Custom playlist logic
                     List<(Movie Movie, DateTime StartTime, DateTime EndTime)> moviesForPeriod = customPlayListBuilder.GetMoviesForPeriod(service.CallSign, DateTime.UtcNow, sdSettings.SDEPGDays);

--- a/src/StreamMaster.SchedulesDirect/Converters/XmltvProgramBuilder.cs
+++ b/src/StreamMaster.SchedulesDirect/Converters/XmltvProgramBuilder.cs
@@ -319,7 +319,7 @@ namespace StreamMaster.SchedulesDirect.Converters
 
                 list.Add(new XmltvEpisodeNum { System = "xmltv_ns", Text = text });
             }
-            else if (mxfProgram.EPGNumber is EPGHelper.DummyId or EPGHelper.CustomPlayListId)
+            else if (mxfProgram.EPGNumber is EPGHelper.UserId or EPGHelper.MovieId)
             {
                 list.Add(new XmltvEpisodeNum { System = "original-air-date", Text = $"{scheduleEntry.StartTime.ToLocalTime():yyyy-MM-dd}" });
             }

--- a/src/StreamMaster.SchedulesDirect/Data/SchedulesDirectDataService.cs
+++ b/src/StreamMaster.SchedulesDirect/Data/SchedulesDirectDataService.cs
@@ -69,11 +69,11 @@ public class SchedulesDirectDataService()
 
     public ICustomStreamData CustomStreamData()
     {
-        return CustomStreamDatas.GetOrAdd(EPGHelper.CustomPlayListId, (_) =>
+        return CustomStreamDatas.GetOrAdd(EPGHelper.MovieId, (_) =>
         {
-            CustomStreamData data = new(EPGHelper.CustomPlayListId)
+            CustomStreamData data = new(EPGHelper.MovieId)
             {
-                EPGNumber = EPGHelper.CustomPlayListId
+                EPGNumber = EPGHelper.MovieId
             };
             return data;
         });

--- a/src/StreamMaster.Streams/Channels/ChannelService.cs
+++ b/src/StreamMaster.Streams/Channels/ChannelService.cs
@@ -424,7 +424,7 @@ public sealed class ChannelService : IChannelService
             Id = channelBroadcaster.SMChannel.Id.ToString(),
             Name = channelBroadcaster.SMChannel.Name,
             Url = channelBroadcaster.SMChannel.Id.ToString(),
-            SMStreamType = SMStreamTypeEnum.Custom,
+            SMStreamType = SMStreamTypeEnum.Movie,
             ClientUserAgent = "",
             CommandProfile = new()
         };

--- a/src/StreamMaster.Streams/Factories/StreamFactory.cs
+++ b/src/StreamMaster.Streams/Factories/StreamFactory.cs
@@ -59,7 +59,7 @@ public sealed class StreamFactory(
 
             return smStreamInfo.SMStreamType switch
             {
-                SMStreamTypeEnum.CustomPlayList or SMStreamTypeEnum.Intro or SMStreamTypeEnum.Message
+                SMStreamTypeEnum.Movie or SMStreamTypeEnum.Intro or SMStreamTypeEnum.Message
                     => await customPlayListStream.HandleStream(smStreamInfo, clientUserAgent, cancellationToken).ConfigureAwait(false),
 
                 _ when smStreamInfo.Url.EndsWith(".m3u8")
@@ -82,6 +82,7 @@ public sealed class StreamFactory(
             stopwatch.Stop();
         }
     }
+
     private GetStreamResult ExecuteCommandForM3U8(SMStreamInfo smStreamInfo, string clientUserAgent, CancellationToken cancellationToken)
     {
         CommandProfileDto commandProfileDto = profileService.GetM3U8OutputProfile(smStreamInfo.Id);

--- a/src/StreamMaster.Streams/Services/SwitchToNextStreamService.cs
+++ b/src/StreamMaster.Streams/Services/SwitchToNextStreamService.cs
@@ -16,7 +16,6 @@ public sealed class SwitchToNextStreamService(
     IServiceProvider serviceProvider,
     IIntroPlayListBuilder introPlayListBuilder,
     ICustomPlayListBuilder customPlayListBuilder,
-        IStreamConnectionService streamConnectionService,
     IOptionsMonitor<Setting> settingsMonitor) : ISwitchToNextStreamService
 {
     /// <inheritdoc/>
@@ -54,7 +53,7 @@ public sealed class SwitchToNextStreamService(
             ? HandleStreamLimits(channelStatus, settings)
             : smStream.SMStreamType switch
             {
-                SMStreamTypeEnum.CustomPlayList => HandleCustomPlayListStream(channelStatus, smStream, settings),
+                SMStreamTypeEnum.Movie => HandleCustomPlayListStream(channelStatus, smStream, settings),
                 SMStreamTypeEnum.Intro => HandleIntroStream(channelStatus, smStream, settings),
                 _ => await HandleStandardStreamAsync(scope, channelStatus, smStream, settings).ConfigureAwait(false)
             };
@@ -107,7 +106,7 @@ public sealed class SwitchToNextStreamService(
             Id = introPlayList.Name,
             Name = introPlayList.Name,
             Url = introPlayList.CustomStreamNfos[0].VideoFileName,
-            SMStreamType = SMStreamTypeEnum.CustomPlayList,
+            SMStreamType = SMStreamTypeEnum.Movie,
             ClientUserAgent = GetClientUserAgent(channelStatus.SMChannel, smStream, settings),
             CommandProfile = customPlayListProfile
         };
@@ -234,7 +233,7 @@ public sealed class SwitchToNextStreamService(
             Id = streamNfo.StreamNfo.Movie.Title,
             Name = streamNfo.StreamNfo.Movie.Title,
             Url = streamNfo.StreamNfo.VideoFileName,
-            SMStreamType = SMStreamTypeEnum.CustomPlayList,
+            SMStreamType = SMStreamTypeEnum.Movie,
             SecondsIn = streamNfo.SecondsIn,
             ClientUserAgent = GetClientUserAgent(channelStatus.SMChannel, smStream, settings),
             CommandProfile = customPlayListProfile

--- a/src/StreamMaster.WebUI/lib/smAPI/smapiTypes.ts
+++ b/src/StreamMaster.WebUI/lib/smAPI/smapiTypes.ts
@@ -1787,12 +1787,8 @@ export enum M3UKey {
 }
 export enum SMChannelTypeEnum {
 	Regular = 0,
-	MultiView = 1
-}
-export enum SMStreamTypeEnum {
-	Regular = 0,
-	CustomPlayList = 1,
-	Custom = 2,
+	MultiView = 1,
+	Movie = 2,
 	Intro = 3,
 	Message = 4
 }
@@ -1809,6 +1805,13 @@ export enum SMFileTypes {
 	CustomPlayList = 9,
 	CustomPlayListLogo = 10,
 	ProgramLogo = 11
+}
+export enum SMStreamTypeEnum {
+	Regular = 0,
+	User = 1,
+	Movie = 2,
+	Intro = 3,
+	Message = 4
 }
 export enum ValidM3USetting {
 	NotMapped = 0,

--- a/src/tests/StreamMaster.Application.UnitTests/EPG/Commands/XMLTVBuilderTests.cs
+++ b/src/tests/StreamMaster.Application.UnitTests/EPG/Commands/XMLTVBuilderTests.cs
@@ -14,6 +14,8 @@ using StreamMaster.PlayList;
 using StreamMaster.PlayList.Models;
 using System.Globalization;
 
+namespace StreamMaster.Application.UnitTests.EPG.Commands;
+
 public class XMLTVBuilderTests : IDisposable
 {
     private readonly Mock<IOptionsMonitor<SDSettings>> _sdSettingsMock = new();

--- a/src/tests/StreamMaster.Application.UnitTests/StreamGroups/StreamGroupServiceCryptoTests.cs
+++ b/src/tests/StreamMaster.Application.UnitTests/StreamGroups/StreamGroupServiceCryptoTests.cs
@@ -1,0 +1,160 @@
+﻿using Moq;
+using Shouldly;
+using StreamMaster.Domain.Crypto;
+using StreamMaster.Domain.Models;
+using System.Collections.Concurrent;
+
+namespace StreamMaster.Application.UnitTests.StreamGroups;
+
+public partial class StreamGroupServiceTests : IDisposable
+{
+    [Fact]
+    public async Task EncodeStreamGroupIdProfileIdAsync_ValidInput_ReturnsEncodedString()
+    {
+        // Arrange
+        int streamGroupId = 1;
+        int streamGroupProfileId = 2;
+        string groupKey = "TestGroupKey123";
+
+        // Create a mock dictionary with our test data
+        var mockDictionary = new ConcurrentDictionary<int, string?>();
+        mockDictionary.TryAdd(streamGroupId, groupKey);
+
+        // Set up the cache manager to return our mock dictionary
+        _cacheManager.Setup(x => x.StreamGroupKeyCache)
+            .Returns(mockDictionary);
+
+        // Act
+        string? result = await _streamGroupService.EncodeStreamGroupIdProfileIdAsync(streamGroupId, streamGroupProfileId);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldNotBeEmpty();
+
+        (int? decodedStreamGroupId, string? valuesEncryptedString) = CryptoUtils.DecodeStreamGroupId(result, _settingsValue.ServerKey);
+        decodedStreamGroupId.ShouldBe(streamGroupId);
+        valuesEncryptedString.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task EncodeStreamGroupIdProfileIdAsync_InvalidGroupKey_ReturnsNull()
+    {
+        // Arrange
+        int streamGroupId = 1;
+        int streamGroupProfileId = 2;
+
+        // Create a mock dictionary to return
+        var mockDictionary = new ConcurrentDictionary<int, string?>();
+
+        // Set up the cache manager to return our mock dictionary
+        _cacheManager.Setup(x => x.StreamGroupKeyCache)
+            .Returns(mockDictionary);
+
+        _repositoryWrapper.Setup(x => x.StreamGroup.FirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroup, bool>>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StreamGroup?)null);
+
+        // Act
+        string? result = await _streamGroupService.EncodeStreamGroupIdProfileIdAsync(streamGroupId, streamGroupProfileId);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task DecodeStreamGroupIdProfileIdFromEncodedAsync_ValidInput_ReturnsDecodedValues()
+    {
+        // Arrange
+        int streamGroupId = 1;
+        int streamGroupProfileId = 2;
+        string groupKey = "TestGroupKey123";
+
+        string encodedString = CryptoUtils.EncodeTwoValues(streamGroupId, streamGroupProfileId, _settingsValue.ServerKey, groupKey);
+
+        var streamGroup = new StreamGroup { Id = streamGroupId, GroupKey = groupKey };
+        _repositoryWrapper.Setup(x => x.StreamGroup.FirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroup, bool>>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(streamGroup);
+
+        // Act
+        var result = await _streamGroupService.DecodeStreamGroupIdProfileIdFromEncodedAsync(encodedString);
+
+        // Assert
+        result.StreamGroupId.ShouldBe(streamGroupId);
+        result.StreamGroupProfileId.ShouldBe(streamGroupProfileId);
+    }
+
+    [Fact]
+    public async Task DecodeProfileIdSMChannelIdFromEncodedAsync_ValidInput_ReturnsDecodedValues()
+    {
+        // Arrange
+        int streamGroupId = 1;
+        int streamGroupProfileId = 2;
+        int smChannelId = 3;
+        string groupKey = "TestGroupKey123";
+
+        string encodedString = CryptoUtils.EncodeThreeValues(streamGroupId, streamGroupProfileId, smChannelId, _settingsValue.ServerKey, groupKey);
+
+        var streamGroup = new StreamGroup { Id = streamGroupId, GroupKey = groupKey };
+        _repositoryWrapper.Setup(x => x.StreamGroup.FirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroup, bool>>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(streamGroup);
+
+        // Act
+        var result = await _streamGroupService.DecodeProfileIdSMChannelIdFromEncodedAsync(encodedString);
+
+        // Assert
+        result.StreamGroupId.ShouldBe(streamGroupId);
+        result.StreamGroupProfileId.ShouldBe(streamGroupProfileId);
+        result.SMChannelId.ShouldBe(smChannelId);
+    }
+
+    [Fact]
+    public void EncodeProfileIds_ValidInput_ReturnsEncodedString()
+    {
+        // Arrange
+        List<int> profileIds = [1, 2, 3];
+
+        // Act
+        string result = _streamGroupService.EncodeProfileIds(profileIds);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldNotBeEmpty();
+
+        string? decodedJson = CryptoUtils.DecodeValue(result, _settingsValue.ServerKey);
+        decodedJson.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void DecodeProfileIds_ValidInput_ReturnsDecodedList()
+    {
+        // Arrange
+        List<int> profileIds = [1, 2, 3];
+        string json = System.Text.Json.JsonSerializer.Serialize(profileIds);
+
+        string encodedString = CryptoUtils.EncodeValue(json, _settingsValue.ServerKey);
+
+        // Act
+        List<int>? result = _streamGroupService.DecodeProfileIds(encodedString);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(3);
+        result.ShouldContain(1);
+        result.ShouldContain(2);
+        result.ShouldContain(3);
+    }
+
+    [Fact]
+    public void DecodeProfileIds_InvalidInput_ReturnsEmptyList()
+    {
+        // Arrange
+        string encodedString = "InvalidEncodedString";
+        CryptoUtils.EncodeValue("invalid", _settingsValue.ServerKey);
+
+        // Act
+        List<int>? result = _streamGroupService.DecodeProfileIds(encodedString);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(0);
+    }
+}

--- a/src/tests/StreamMaster.Application.UnitTests/StreamGroups/StreamGroupServiceLineupTests.cs
+++ b/src/tests/StreamMaster.Application.UnitTests/StreamGroups/StreamGroupServiceLineupTests.cs
@@ -1,0 +1,237 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using MockQueryable;
+using Moq;
+using Shouldly;
+using StreamMaster.Application.StreamGroups;
+using StreamMaster.Domain.Common;
+using StreamMaster.Domain.Configuration;
+using StreamMaster.Domain.Models;
+using StreamMaster.Domain.Repository;
+using StreamMaster.Domain.Services;
+using StreamMaster.Domain.XmltvXml;
+using StreamMaster.Streams.Domain.Interfaces;
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace StreamMaster.Application.UnitTests.StreamGroups;
+
+public partial class StreamGroupServiceTests
+{
+    [Fact]
+    public async Task GetStreamGroupLineupAsync_ValidInput_ReturnsLineupJson()
+    {
+        // Arrange
+        int streamGroupProfileId = 1;
+        var streamGroup = new StreamGroup { Id = 2, Name = "TestGroup", GroupKey = "testkey" };
+        var streamGroupProfile = new StreamGroupProfile { Id = streamGroupProfileId, StreamGroupId = streamGroup.Id, CommandProfileName = "Default", OutputProfileName = "Default" };
+        var defaultStreamGroup = new StreamGroup { Id = 1, Name = BuildInfo.DefaultStreamGroupName, GroupKey = "defaultkey" };
+        var defaultStreamGroupProfile = new StreamGroupProfile { Id = 3, StreamGroupId = defaultStreamGroup.Id, ProfileName = "Default", CommandProfileName = "Default", OutputProfileName = "Default" };
+
+        // Mock repository wrapper
+        var mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+
+        // Setup StreamGroupProfile using MockQueryable
+        var streamGroupProfiles = new List<StreamGroupProfile> { streamGroupProfile, defaultStreamGroupProfile };
+        var mockStreamGroupProfileQueryable = streamGroupProfiles.AsQueryable().BuildMock();
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroupProfile.GetQuery(It.IsAny<bool>()))
+            .Returns(mockStreamGroupProfileQueryable);
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroupProfile.FirstOrDefaultAsync(
+            It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroupProfile, bool>>>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync((System.Linq.Expressions.Expression<Func<StreamGroupProfile, bool>> predicate, bool tracking, CancellationToken token) =>
+                streamGroupProfiles.FirstOrDefault(predicate.Compile()));
+
+        // Setup StreamGroup using MockQueryable
+        var streamGroups = new List<StreamGroup> { streamGroup, defaultStreamGroup };
+        var mockStreamGroupQueryable = streamGroups.AsQueryable().BuildMock();
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroup.GetQuery(It.IsAny<bool>()))
+            .Returns(mockStreamGroupQueryable);
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroup.FirstOrDefaultAsync(
+            It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroup, bool>>>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync((System.Linq.Expressions.Expression<Func<StreamGroup, bool>> predicate, bool tracking, CancellationToken token) =>
+                streamGroups.FirstOrDefault(predicate.Compile()));
+
+        // Setup SMChannel
+        var smChannels = new List<SMChannel>
+    {
+        new SMChannel { Id = 3, Name = "Test Channel", ChannelNumber = 1, EPGId = "test-epg", IsHidden = false }
+    };
+        var mockSmChannelQueryable = smChannels.AsQueryable().BuildMock();
+
+        mockRepositoryWrapper.Setup(x => x.SMChannel.GetQuery(It.IsAny<bool>()))
+            .Returns(mockSmChannelQueryable);
+
+        mockRepositoryWrapper.Setup(x => x.SMChannel.GetSMChannelsFromStreamGroup(streamGroup.Id))
+            .ReturnsAsync(smChannels);
+
+        // Mock HttpContextAccessor
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        var mockHttpContext = new Mock<HttpContext>();
+        var mockHttpRequest = new Mock<HttpRequest>();
+
+        mockHttpRequest.Setup(x => x.Scheme).Returns("http");
+        mockHttpRequest.Setup(x => x.Host).Returns(new HostString("localhost"));
+        mockHttpRequest.Setup(x => x.PathBase).Returns(new PathString(""));
+
+        mockHttpContext.Setup(x => x.Request).Returns(mockHttpRequest.Object);
+        mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+        // Mock other required services
+        var mockLogoService = new Mock<ILogoService>();
+        mockLogoService.Setup(x => x.GetLogoUrl(It.IsAny<SMChannel>(), It.IsAny<string>()))
+            .Returns("http://localhost/logo");
+
+        var mockSettings = new Mock<IOptionsMonitor<Setting>>();
+        mockSettings.Setup(x => x.CurrentValue).Returns(new Setting { ServerKey = "testserverkey" });
+
+        var mockCommandProfileSettings = new Mock<IOptionsMonitor<CommandProfileDict>>();
+        mockCommandProfileSettings.Setup(x => x.CurrentValue).Returns(new CommandProfileDict());
+
+        var mockCacheManager = new Mock<ICacheManager>();
+        mockCacheManager.Setup(x => x.StreamGroupKeyCache).Returns(new ConcurrentDictionary<int, string?>());
+        mockCacheManager.Setup(x => x.StationChannelNames).Returns(new ConcurrentDictionary<int, List<StationChannelName>>());
+
+        // Setup DefaultSG in cache manager
+        mockCacheManager.Setup(x => x.DefaultSG).Returns(defaultStreamGroup);
+
+        var mockProfileService = new Mock<IProfileService>();
+        mockProfileService.Setup(x => x.GetCommandProfile(It.IsAny<string>()))
+            .Returns(new CommandProfileDto());
+        mockProfileService.Setup(x => x.GetOutputProfile(It.IsAny<string>()))
+            .Returns(new OutputProfileDto());
+
+        // Create service with all dependencies
+        var streamGroupService = new StreamGroupService(
+            mockHttpContextAccessor.Object,
+            mockLogoService.Object,
+            mockSettings.Object,
+            mockCommandProfileSettings.Object,
+            mockCacheManager.Object,
+            mockRepositoryWrapper.Object,
+            mockProfileService.Object);
+
+        // Act
+        string result = await streamGroupService.GetStreamGroupLineupAsync(streamGroupProfileId, true);
+
+        // Assert
+        result.ShouldNotBeNull();
+
+        // Assert the content of the JSON
+        var lineup = JsonSerializer.Deserialize<List<SGLineup>>(result);
+        lineup.ShouldNotBeNull();
+        lineup.Count.ShouldBe(1); // Assert that a single entry is in the lineup
+        lineup[0].GuideNumber.ShouldBe("1");
+        lineup[0].GuideName.ShouldBe("Test Channel");
+        lineup[0].URL.ShouldContain("/v/1/3"); // Short URL format with streamGroupProfileId/channelId
+    }
+
+    [Fact]
+    public async Task GetStreamGroupLineupAsync_EmptyChannels_ReturnsEmptyJson()
+    {
+        // Arrange
+        int streamGroupProfileId = 1;
+        var streamGroup = new StreamGroup { Id = 2, Name = "TestGroup", GroupKey = "testkey" };
+        var streamGroupProfile = new StreamGroupProfile { Id = streamGroupProfileId, StreamGroupId = streamGroup.Id, CommandProfileName = "Default", OutputProfileName = "Default" };
+        var defaultStreamGroup = new StreamGroup { Id = 1, Name = BuildInfo.DefaultStreamGroupName, GroupKey = "defaultkey" };
+        var defaultStreamGroupProfile = new StreamGroupProfile { Id = 3, StreamGroupId = defaultStreamGroup.Id, ProfileName = "Default", CommandProfileName = "Default", OutputProfileName = "Default" };
+
+        // Mock repository wrapper
+        var mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+
+        // Setup StreamGroupProfile using MockQueryable
+        var streamGroupProfiles = new List<StreamGroupProfile> { streamGroupProfile, defaultStreamGroupProfile };
+        var mockStreamGroupProfileQueryable = streamGroupProfiles.AsQueryable().BuildMock();
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroupProfile.GetQuery(It.IsAny<bool>()))
+            .Returns(mockStreamGroupProfileQueryable);
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroupProfile.FirstOrDefaultAsync(
+            It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroupProfile, bool>>>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync((System.Linq.Expressions.Expression<Func<StreamGroupProfile, bool>> predicate, bool tracking, CancellationToken token) =>
+                streamGroupProfiles.FirstOrDefault(predicate.Compile()));
+
+        // Setup StreamGroup using MockQueryable
+        var streamGroups = new List<StreamGroup> { streamGroup, defaultStreamGroup };
+        var mockStreamGroupQueryable = streamGroups.AsQueryable().BuildMock();
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroup.GetQuery(It.IsAny<bool>()))
+            .Returns(mockStreamGroupQueryable);
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroup.FirstOrDefaultAsync(
+            It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroup, bool>>>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync((System.Linq.Expressions.Expression<Func<StreamGroup, bool>> predicate, bool tracking, CancellationToken token) =>
+                streamGroups.FirstOrDefault(predicate.Compile()));
+
+        // Setup empty SMChannel list
+        mockRepositoryWrapper.Setup(x => x.SMChannel.GetSMChannelsFromStreamGroup(streamGroup.Id))
+            .ReturnsAsync(new List<SMChannel>());
+
+        // Setup empty SMChannel queryable
+        var emptySmChannels = new List<SMChannel>();
+        var mockSmChannelQueryable = emptySmChannels.AsQueryable().BuildMock();
+
+        mockRepositoryWrapper.Setup(x => x.SMChannel.GetQuery(It.IsAny<bool>()))
+            .Returns(mockSmChannelQueryable);
+
+        // Mock HttpContextAccessor
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        var mockHttpContext = new Mock<HttpContext>();
+        var mockHttpRequest = new Mock<HttpRequest>();
+
+        mockHttpRequest.Setup(x => x.Scheme).Returns("http");
+        mockHttpRequest.Setup(x => x.Host).Returns(new HostString("localhost"));
+        mockHttpRequest.Setup(x => x.PathBase).Returns(new PathString(""));
+
+        mockHttpContext.Setup(x => x.Request).Returns(mockHttpRequest.Object);
+        mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(mockHttpContext.Object);
+
+        // Mock other required services
+        var mockLogoService = new Mock<ILogoService>();
+        var mockSettings = new Mock<IOptionsMonitor<Setting>>();
+        mockSettings.Setup(x => x.CurrentValue).Returns(new Setting { ServerKey = "testserverkey" });
+
+        var mockCommandProfileSettings = new Mock<IOptionsMonitor<CommandProfileDict>>();
+        mockCommandProfileSettings.Setup(x => x.CurrentValue).Returns(new CommandProfileDict());
+
+        var mockCacheManager = new Mock<ICacheManager>();
+        mockCacheManager.Setup(x => x.StreamGroupKeyCache).Returns(new ConcurrentDictionary<int, string?>());
+        mockCacheManager.Setup(x => x.StationChannelNames).Returns(new ConcurrentDictionary<int, List<StationChannelName>>());
+
+        // Setup DefaultSG in cache manager
+        mockCacheManager.Setup(x => x.DefaultSG).Returns(defaultStreamGroup);
+
+        var mockProfileService = new Mock<IProfileService>();
+        mockProfileService.Setup(x => x.GetCommandProfile(It.IsAny<string>()))
+            .Returns(new CommandProfileDto());
+        mockProfileService.Setup(x => x.GetOutputProfile(It.IsAny<string>()))
+            .Returns(new OutputProfileDto());
+
+        // Create service with all dependencies
+        var streamGroupService = new StreamGroupService(
+            mockHttpContextAccessor.Object,
+            mockLogoService.Object,
+            mockSettings.Object,
+            mockCommandProfileSettings.Object,
+            mockCacheManager.Object,
+            mockRepositoryWrapper.Object,
+            mockProfileService.Object);
+
+        // Act
+        string result = await streamGroupService.GetStreamGroupLineupAsync(streamGroupProfileId, true);
+
+        // Assert
+        result.ShouldBe("[]");
+    }
+}

--- a/src/tests/StreamMaster.Application.UnitTests/StreamGroups/StreamGroupServiceProfileTests.cs
+++ b/src/tests/StreamMaster.Application.UnitTests/StreamGroups/StreamGroupServiceProfileTests.cs
@@ -1,0 +1,244 @@
+﻿using MockQueryable.Moq;
+using Moq;
+using Shouldly;
+using StreamMaster.Domain.Configuration;
+using StreamMaster.Domain.Models;
+
+namespace StreamMaster.Application.UnitTests.StreamGroups;
+
+public partial class StreamGroupServiceTests
+{
+    [Fact]
+    public async Task GetProfileFromSGIdsCommandProfileNameAsync_NonDefaultCommandProfile_ReturnsCommandProfile()
+    {
+        // Arrange
+        int streamGroupId = 1;
+        int streamGroupProfileId = 2;
+        string commandProfileName = "CustomProfile";
+
+        // Create a StreamGroupProfile that will be returned by GetStreamGroupProfileAsync
+        var streamGroupProfile = new StreamGroupProfile
+        {
+            Id = streamGroupProfileId,
+            StreamGroupId = streamGroupId,
+            CommandProfileName = "Default" // Using Default so it will use the requested profile
+        };
+
+        // Set up the mock queryable for StreamGroupProfile
+        var streamGroupProfiles = new List<StreamGroupProfile> { streamGroupProfile };
+        var mockDbSet = streamGroupProfiles.AsQueryable().BuildMockDbSet();
+        _repositoryWrapper.Setup(x => x.StreamGroupProfile.GetQuery(It.IsAny<bool>()))
+            .Returns(mockDbSet.Object);
+
+        var commandProfileDict = new CommandProfileDict();
+        var commandProfile = new CommandProfile
+        {
+            Command = "ffmpeg",
+            Parameters = "-test",
+            IsReadOnly = false
+        };
+        commandProfileDict.AddProfile(commandProfileName, commandProfile);
+
+        _commandProfileSettings.Setup(x => x.CurrentValue)
+            .Returns(commandProfileDict);
+
+        // Act
+        var result = await _streamGroupService.GetProfileFromSGIdsCommandProfileNameAsync(streamGroupId, streamGroupProfileId, commandProfileName);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ProfileName.ShouldBe(commandProfileName);
+    }
+
+    [Fact]
+    public async Task GetProfileFromSGIdsCommandProfileNameAsync_DefaultCommandProfile_UsesStreamGroupProfileCommandProfile()
+    {
+        // Arrange
+        int streamGroupId = 1;
+        int streamGroupProfileId = 2;
+        string commandProfileName = "Default";
+        string streamGroupProfileCommandName = "CustomProfile";
+
+        var streamGroupProfile = new StreamGroupProfile
+        {
+            Id = streamGroupProfileId,
+            StreamGroupId = streamGroupId,
+            CommandProfileName = streamGroupProfileCommandName
+        };
+
+        // Set up the mock queryable for StreamGroupProfile
+        var streamGroupProfiles = new List<StreamGroupProfile> { streamGroupProfile };
+        var mockDbSet = streamGroupProfiles.AsQueryable().BuildMockDbSet();
+        _repositoryWrapper.Setup(x => x.StreamGroupProfile.GetQuery(It.IsAny<bool>()))
+            .Returns(mockDbSet.Object);
+
+        var commandProfileDict = new CommandProfileDict();
+        var commandProfile = new CommandProfile
+        {
+            Command = "ffmpeg",
+            Parameters = "-test",
+            IsReadOnly = false
+        };
+        commandProfileDict.AddProfile(streamGroupProfileCommandName, commandProfile);
+
+        // Set up the settings to return our dictionary
+        _commandProfileSettings.Setup(x => x.CurrentValue)
+            .Returns(commandProfileDict);
+
+        // Act
+        var result = await _streamGroupService.GetProfileFromSGIdsCommandProfileNameAsync(streamGroupId, streamGroupProfileId, commandProfileName);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ProfileName.ShouldBe(streamGroupProfileCommandName);
+    }
+
+    [Fact]
+    public async Task GetProfileFromSGIdsCommandProfileNameAsync_DefaultCommandProfileAndDefaultStreamGroupProfile_UsesSettingsDefaultCommandProfile()
+    {
+        // Arrange
+        int streamGroupId = 1;
+        int streamGroupProfileId = 2;
+        string commandProfileName = "Default";
+        string streamGroupProfileCommandName = "Default";
+        string settingsDefaultCommandName = "DefaultCommandProfile";
+
+        var streamGroupProfile = new StreamGroupProfile
+        {
+            Id = streamGroupProfileId,
+            StreamGroupId = streamGroupId,
+            CommandProfileName = streamGroupProfileCommandName
+        };
+
+        // Set up the mock queryable for StreamGroupProfile
+        var streamGroupProfiles = new List<StreamGroupProfile> { streamGroupProfile };
+        var mockDbSet = streamGroupProfiles.AsQueryable().BuildMockDbSet();
+        _repositoryWrapper.Setup(x => x.StreamGroupProfile.GetQuery(It.IsAny<bool>()))
+            .Returns(mockDbSet.Object);
+
+        var commandProfileDict = new CommandProfileDict();
+        var commandProfile = new CommandProfile
+        {
+            Command = "ffmpeg",
+            Parameters = "-test",
+            IsReadOnly = false
+        };
+        commandProfileDict.AddProfile(settingsDefaultCommandName, commandProfile);
+
+        _commandProfileSettings.Setup(x => x.CurrentValue)
+            .Returns(commandProfileDict);
+
+        _settings.Setup(x => x.CurrentValue)
+            .Returns(new Setting { DefaultCommandProfileName = settingsDefaultCommandName });
+
+        // Act
+        var result = await _streamGroupService.GetProfileFromSGIdsCommandProfileNameAsync(streamGroupId, streamGroupProfileId, commandProfileName);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ProfileName.ShouldBe(settingsDefaultCommandName);
+    }
+
+    [Fact]
+    public async Task GetProfileFromSGIdsCommandProfileNameAsync_StreamGroupProfileHasCommandProfile_PrefersStreamGroupProfile()
+    {
+        // Arrange
+        int streamGroupId = 1;
+        int streamGroupProfileId = 2;
+        string requestedCommandProfileName = "RequestedProfile";
+        string streamGroupProfileCommandName = "StreamGroupProfile";
+
+        var streamGroupProfile = new StreamGroupProfile
+        {
+            Id = streamGroupProfileId,
+            StreamGroupId = streamGroupId,
+            CommandProfileName = streamGroupProfileCommandName
+        };
+
+        // Set up the mock queryable for StreamGroupProfile
+        var streamGroupProfiles = new List<StreamGroupProfile> { streamGroupProfile };
+        var mockDbSet = streamGroupProfiles.AsQueryable().BuildMockDbSet();
+        _repositoryWrapper.Setup(x => x.StreamGroupProfile.GetQuery(It.IsAny<bool>()))
+            .Returns(mockDbSet.Object);
+
+        var commandProfileDict = new CommandProfileDict();
+
+        var requestedProfile = new CommandProfile
+        {
+            Command = "requested",
+            Parameters = "-test",
+            IsReadOnly = false
+        };
+
+        var streamGroupCommandProfile = new CommandProfile
+        {
+            Command = "streamgroup",
+            Parameters = "-test",
+            IsReadOnly = false
+        };
+
+        commandProfileDict.AddProfile(requestedCommandProfileName, requestedProfile);
+        commandProfileDict.AddProfile(streamGroupProfileCommandName, streamGroupCommandProfile);
+
+        _commandProfileSettings.Setup(x => x.CurrentValue)
+            .Returns(commandProfileDict);
+
+        // Act
+        var result = await _streamGroupService.GetProfileFromSGIdsCommandProfileNameAsync(streamGroupId, streamGroupProfileId, requestedCommandProfileName);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ProfileName.ShouldBe(streamGroupProfileCommandName);
+        result.Command.ShouldBe("streamgroup");
+    }
+
+    [Fact]
+    public async Task GetProfileFromSGIdsCommandProfileNameAsync_NonExistentRequestedProfile_FallsBackToDefault()
+    {
+        // Arrange
+        int streamGroupId = 1;
+        int streamGroupProfileId = 2;
+        string requestedCommandProfileName = "NonExistentProfile";
+        string defaultCommandProfileName = "DefaultCommandProfile";
+
+        var streamGroupProfile = new StreamGroupProfile
+        {
+            Id = streamGroupProfileId,
+            StreamGroupId = streamGroupId,
+            CommandProfileName = "Default"
+        };
+
+        // Set up the mock queryable for StreamGroupProfile
+        var streamGroupProfiles = new List<StreamGroupProfile> { streamGroupProfile };
+        var mockDbSet = streamGroupProfiles.AsQueryable().BuildMockDbSet();
+        _repositoryWrapper.Setup(x => x.StreamGroupProfile.GetQuery(It.IsAny<bool>()))
+            .Returns(mockDbSet.Object);
+
+        var commandProfileDict = new CommandProfileDict();
+
+        var defaultProfile = new CommandProfile
+        {
+            Command = "default",
+            Parameters = "-test",
+            IsReadOnly = false
+        };
+
+        commandProfileDict.AddProfile(defaultCommandProfileName, defaultProfile);
+
+        // Setup the mock to return our dictionary
+        _commandProfileSettings.Setup(x => x.CurrentValue)
+            .Returns(commandProfileDict);
+
+        // Setup the settings to return our default profile name
+        _settings.Setup(x => x.CurrentValue)
+            .Returns(new Setting { DefaultCommandProfileName = defaultCommandProfileName });
+
+        // Act
+        var result = await _streamGroupService.GetProfileFromSGIdsCommandProfileNameAsync(streamGroupId, streamGroupProfileId, requestedCommandProfileName);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ProfileName.ShouldBe(defaultCommandProfileName);
+        result.Command.ShouldBe("default");
+    }
+}

--- a/src/tests/StreamMaster.Application.UnitTests/StreamGroups/StreamGroupServiceTests.cs
+++ b/src/tests/StreamMaster.Application.UnitTests/StreamGroups/StreamGroupServiceTests.cs
@@ -1,0 +1,276 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using MockQueryable;
+using Moq;
+using Shouldly;
+using StreamMaster.Application.StreamGroups;
+using StreamMaster.Domain.Configuration;
+using StreamMaster.Domain.Models;
+using StreamMaster.Domain.Repository;
+using StreamMaster.Domain.Services;
+using StreamMaster.Streams.Domain.Interfaces;
+
+namespace StreamMaster.Application.UnitTests.StreamGroups;
+
+public partial class StreamGroupServiceTests : IDisposable
+{
+    private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+    private readonly Mock<ILogoService> _logoService;
+    private readonly Mock<IOptionsMonitor<Setting>> _settings;
+    private readonly Mock<IOptionsMonitor<CommandProfileDict>> _commandProfileSettings;
+    private readonly Mock<ICacheManager> _cacheManager;
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapper;
+    private readonly Mock<IProfileService> _profileService;
+    private readonly StreamGroupService _streamGroupService;
+    private readonly Setting _settingsValue;
+    private readonly CommandProfileDict _commandProfileDictValue;
+    private readonly MemoryCache _memoryCache;
+
+    public StreamGroupServiceTests()
+    {
+        _httpContextAccessor = new Mock<IHttpContextAccessor>();
+        _logoService = new Mock<ILogoService>();
+        _settings = new Mock<IOptionsMonitor<Setting>>();
+        _commandProfileSettings = new Mock<IOptionsMonitor<CommandProfileDict>>();
+        _cacheManager = new Mock<ICacheManager>();
+        _repositoryWrapper = new Mock<IRepositoryWrapper>();
+        _profileService = new Mock<IProfileService>();
+        _memoryCache = new MemoryCache(new MemoryCacheOptions());
+
+        _settingsValue = new Setting
+        {
+            ServerKey = "TestServerKey123", // Use a consistent key for encryption/decryption
+            LogoCache = true,
+            STRMBaseURL = "http://localhost",
+            DefaultCommandProfileName = "DefaultCommandProfile"
+        };
+
+        _commandProfileDictValue = new CommandProfileDict
+        {
+            CommandProfiles = new Dictionary<string, CommandProfile>
+            {
+                { "Default", new CommandProfile { Command = "DefaultCommand" } },
+                { "CustomProfile", new CommandProfile { Command = "CustomProfileCommand" } },
+                { "DefaultCommandProfile", new CommandProfile { Command = "DefaultCommandProfileCommand" } }
+            }
+        };
+
+        _settings.Setup(x => x.CurrentValue).Returns(_settingsValue);
+        _commandProfileSettings.Setup(x => x.CurrentValue).Returns(_commandProfileDictValue);
+
+        _streamGroupService = new StreamGroupService(
+            _httpContextAccessor.Object,
+            _logoService.Object,
+            _settings.Object,
+            _commandProfileSettings.Object,
+            _cacheManager.Object,
+            _repositoryWrapper.Object,
+            _profileService.Object
+        );
+    }
+
+    public void Dispose()
+    {
+        _memoryCache.Dispose();
+    }
+
+    internal StreamGroupService GetStreamGroupService(
+        IHttpContextAccessor? httpContextAccessor = null,
+        ILogoService? logoService = null,
+        IOptionsMonitor<Setting>? settings = null,
+        IOptionsMonitor<CommandProfileDict>? commandProfileSettings = null,
+        ICacheManager? cacheManager = null,
+        IRepositoryWrapper? repositoryWrapper = null,
+        IProfileService? profileService = null)
+    {
+        // Provide default mock instances if any of the dependencies are not explicitly passed in.
+        httpContextAccessor ??= Mock.Of<IHttpContextAccessor>();
+        logoService ??= Mock.Of<ILogoService>();
+        settings ??= Mock.Of<IOptionsMonitor<Setting>>();
+        commandProfileSettings ??= Mock.Of<IOptionsMonitor<CommandProfileDict>>();
+        cacheManager ??= Mock.Of<ICacheManager>();
+        repositoryWrapper ??= Mock.Of<IRepositoryWrapper>();
+        profileService ??= Mock.Of<IProfileService>();
+
+        return new StreamGroupService(
+            httpContextAccessor,
+            logoService,
+            settings,
+            commandProfileSettings,
+            cacheManager,
+            repositoryWrapper,
+            profileService
+        );
+    }
+
+    [Fact]
+    public async Task GetStreamGroupIdFromSGProfileIdAsync_ValidProfileId_ReturnsStreamGroupId()
+    {
+        // Arrange
+        int streamGroupProfileId = 1;
+        int streamGroupId = 2;
+        var streamGroup = new StreamGroup { Id = streamGroupId, Name = "TestGroup" };
+        var mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroupProfile.GetQuery(It.IsAny<bool>()))
+            .Returns(new List<StreamGroupProfile>
+            {
+                new StreamGroupProfile { Id = streamGroupProfileId, StreamGroupId = streamGroupId }
+            }.AsQueryable());
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroup.FirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroup, bool>>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(streamGroup);
+
+        var mockStreamGroupService = GetStreamGroupService(repositoryWrapper: mockRepositoryWrapper.Object);
+
+        // Act
+        int result = await mockStreamGroupService.GetStreamGroupIdFromSGProfileIdAsync(streamGroupProfileId);
+
+        // Assert
+        result.ShouldBe(streamGroupId);
+    }
+
+    [Fact]
+    public async Task GetStreamGroupIdFromSGProfileIdAsync_InvalidProfileId_ReturnsDefaultStreamGroupId()
+    {
+        // Arrange
+        int? streamGroupProfileId = null;
+        int defaultStreamGroupId = 1;
+        var defaultStreamGroup = new StreamGroup { Id = defaultStreamGroupId, Name = "DefaultStreamGroup" };
+
+        var mockCacheManager = new Mock<ICacheManager>();
+        mockCacheManager.Setup(x => x.DefaultSG).Returns(defaultStreamGroup);
+
+        var mockStreamGroupService = GetStreamGroupService(cacheManager: mockCacheManager.Object);
+        // Act
+        int result = await mockStreamGroupService.GetStreamGroupIdFromSGProfileIdAsync(streamGroupProfileId);
+
+        // Assert
+        result.ShouldBe(defaultStreamGroupId);
+    }
+
+    [Fact]
+    public async Task GetDefaultSGAsync_CachedDefaultSG_ReturnsCachedValue()
+    {
+        // Arrange
+        var defaultStreamGroup = new StreamGroup { Id = 1, Name = "DefaultStreamGroup" };
+        var mockCacheManager = new Mock<ICacheManager>();
+        mockCacheManager.Setup(x => x.DefaultSG).Returns(defaultStreamGroup);
+
+        var mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+
+        var mockStreamGroupService = GetStreamGroupService(cacheManager: mockCacheManager.Object, repositoryWrapper: mockRepositoryWrapper.Object);
+        // Act
+        var result = await mockStreamGroupService.GetDefaultSGAsync();
+
+        // Assert
+        result.ShouldBe(defaultStreamGroup);
+        mockRepositoryWrapper.Verify(x => x.StreamGroup.FirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroup, bool>>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetDefaultSGAsync_NoCachedDefaultSG_FetchesAndCachesDefaultSG()
+    {
+        // Arrange
+        var defaultStreamGroup = new StreamGroup { Id = 1, Name = "DefaultStreamGroup" };
+
+        var mockCacheManager = new Mock<ICacheManager>();
+        mockCacheManager.Setup(x => x.DefaultSG).Returns((StreamGroup?)null);
+
+        var mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        var mockStreamGroupRepository = new Mock<IStreamGroupRepository>();
+
+        mockStreamGroupRepository
+            .Setup(x => x.FirstOrDefaultAsync(
+                It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroup, bool>>>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(defaultStreamGroup);
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroup).Returns(mockStreamGroupRepository.Object);
+
+        var streamGroupService = new StreamGroupService(
+            _httpContextAccessor.Object,
+            _logoService.Object,
+            _settings.Object,
+            _commandProfileSettings.Object,
+            mockCacheManager.Object,
+            mockRepositoryWrapper.Object,
+            _profileService.Object
+        );
+
+        // Act
+        var result = await streamGroupService.GetDefaultSGAsync();
+
+        // Assert
+        result.ShouldBe(defaultStreamGroup);
+        mockCacheManager.VerifySet(x => x.DefaultSG = defaultStreamGroup, Times.Once);
+    }
+
+    [Fact]
+    public async Task GetDefaultSGAsync_DefaultSGNotFound_ThrowsException()
+    {
+        // Arrange
+        var mockCacheManager = new Mock<ICacheManager>();
+        mockCacheManager.Setup(x => x.DefaultSG).Returns((StreamGroup?)null);
+        var mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        mockRepositoryWrapper.Setup(x => x.StreamGroup.FirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroup, bool>>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StreamGroup?)null);
+
+        var mockStreamGroupService = GetStreamGroupService(cacheManager: mockCacheManager.Object, repositoryWrapper: mockRepositoryWrapper.Object);
+
+        // Act & Assert
+        await Should.ThrowAsync<Exception>(async () => await mockStreamGroupService.GetDefaultSGAsync());
+    }
+
+    [Fact]
+    public async Task StreamGroupExistsAsync_ValidProfileId_ReturnsTrue()
+    {
+        // Arrange
+        int streamGroupProfileId = 1;
+        int streamGroupId = 2;
+
+        var streamGroupProfile = new StreamGroupProfile { Id = streamGroupProfileId, StreamGroupId = streamGroupId };
+        var mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroupProfile.FirstOrDefaultAsync(
+            It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroupProfile, bool>>>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(streamGroupProfile);
+
+        var streamGroups = new List<StreamGroup> { new StreamGroup { Id = streamGroupId } };
+        var mockStreamGroups = streamGroups.AsQueryable().BuildMock();
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroup.GetQuery(It.IsAny<bool>()))
+            .Returns(mockStreamGroups);
+
+        var mockStreamGroupService = GetStreamGroupService(repositoryWrapper: mockRepositoryWrapper.Object);
+
+        // Act
+        bool result = await mockStreamGroupService.StreamGroupExistsAsync(streamGroupProfileId);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task StreamGroupExistsAsync_InvalidProfileId_ReturnsFalse()
+    {
+        // Arrange
+        int streamGroupProfileId = 1;
+        var mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+
+        mockRepositoryWrapper.Setup(x => x.StreamGroupProfile.FirstOrDefaultAsync(It.IsAny<System.Linq.Expressions.Expression<Func<StreamGroupProfile, bool>>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StreamGroupProfile?)null);
+
+        var mockStreamGroupService = GetStreamGroupService(repositoryWrapper: mockRepositoryWrapper.Object);
+
+        // Act
+        bool result = await mockStreamGroupService.StreamGroupExistsAsync(streamGroupProfileId);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+}

--- a/src/tests/StreamMaster.Application.UnitTests/StreamMaster.Application.UnitTests.csproj
+++ b/src/tests/StreamMaster.Application.UnitTests/StreamMaster.Application.UnitTests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MockQueryable.Moq" Version="7.0.3" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/src/tests/StreamMaster.Streams.UnitTests/Services/SwitchToNextStreamServiceTests.cs
+++ b/src/tests/StreamMaster.Streams.UnitTests/Services/SwitchToNextStreamServiceTests.cs
@@ -226,7 +226,7 @@ public class SwitchToNextStreamServiceTests
         // Arrange
         var fixture = new TestFixture();
         var status = fixture.CreateChannelStatus();
-        status.SMChannel.SMStreamDtos[0].SMStreamType = SMStreamTypeEnum.CustomPlayList;
+        status.SMChannel.SMStreamDtos[0].SMStreamType = SMStreamTypeEnum.Movie;
 
         var customPlayList = new CustomPlayList
         {
@@ -254,7 +254,7 @@ public class SwitchToNextStreamServiceTests
 
         // Assert
         result.ShouldBeTrue();
-        status.SMStreamInfo.SMStreamType.ShouldBe(SMStreamTypeEnum.CustomPlayList);
+        status.SMStreamInfo.SMStreamType.ShouldBe(SMStreamTypeEnum.Movie);
         status.SMStreamInfo.Name.ShouldBe("TestMovie");
     }
 
@@ -320,7 +320,7 @@ public class SwitchToNextStreamServiceTests
 
         // Assert
         result.ShouldBeTrue();
-        status.SMStreamInfo.SMStreamType.ShouldBe(SMStreamTypeEnum.CustomPlayList);
+        status.SMStreamInfo.SMStreamType.ShouldBe(SMStreamTypeEnum.Movie);
         status.SMStreamInfo.Name.ShouldBe("IntroPlaylist");
     }
 

--- a/src/tests/StreamMaster.Streams.UnitTests/Services/SwitchToNextStreamServiceTests.cs
+++ b/src/tests/StreamMaster.Streams.UnitTests/Services/SwitchToNextStreamServiceTests.cs
@@ -73,7 +73,6 @@ public class SwitchToNextStreamServiceTests
                 ServiceProviderMock.Object,
                 IntroPlayListBuilderMock.Object,
                 CustomPlayListBuilderMock.Object,
-                StreamConnectionServiceMock.Object,
                 SettingsMonitorMock.Object
             );
         }


### PR DESCRIPTION
## Description

Ensure that when a Profile Group is used, that its Command Profile is used when returning a stream.

### Issues (Fixed or Closed)

- Fixes https://github.com/carlreid/StreamMaster/issues/61
- Fixes https://github.com/carlreid/StreamMaster/issues/64

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

1. Create a new Command Profile (`Profiles` -> `Command Profiles` -> `Add`)
2. Define anything you wish, but f.x. call it name `MyCustomProfile`
3. Add this Command Profile to a `Stream Group` (`Stream Groups` -> Reveal a Stream Group details -> Select new profile under `Command Profile`
4. Attempt to play a `Channel` from the `Stream Group`, should use `Stream Group`'s Command Profile

## Checklist

- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/) naming convention
- [x] My branch is up to date with the `main` branch (rebased)
- [x] My code follows the style guidelines and existing patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented complex logic
- [x] I have added tests (if applicable)
- [x] All tests are passing
- [ ] I have updated documentation as needed
