### PR TITLE
Expose toggle for SchedulesDirect Image downloading and correct base URL

### DIFF
--- a/src/StreamMaster.Application/Settings/Commands/UpdateSettingRequest.cs
+++ b/src/StreamMaster.Application/Settings/Commands/UpdateSettingRequest.cs
@@ -48,10 +48,10 @@ public partial class UpdateSettingRequestHandler(
             destination.AlternateLogoStyle = source.AlternateLogoStyle;
         }
 
-        //if (source.SeriesPosterArt.HasValue)
-        //{
-        //    destination.SeriesPosterArt = source.SeriesPosterArt.Value;
-        //}
+        if (source.SeriesPosterArt.HasValue)
+        {
+            destination.SeriesPosterArt = source.SeriesPosterArt.Value;
+        }
 
         if (source.SeriesPosterAspect != null)
         {

--- a/src/StreamMaster.Domain/Configuration/SDSettings.cs
+++ b/src/StreamMaster.Domain/Configuration/SDSettings.cs
@@ -26,6 +26,7 @@
         public List<HeadendToView> HeadendsToView { get; set; } = [];
         public string SDUserName { get; set; } = string.Empty;
         public string UserAgent { get; set; } = "StreamMaster/0.0.0.Sha.0000000000000000000000000000000000000000";
+        public bool SeriesPosterArt { get; set; } = false;
 
         public bool MovieImages { get; set; } = true;
         public bool SeasonImages { get; set; } = false;

--- a/src/StreamMaster.Domain/Configuration/SDSettingsRequest.cs
+++ b/src/StreamMaster.Domain/Configuration/SDSettingsRequest.cs
@@ -5,8 +5,7 @@ public class SDSettingsRequest
 {
     public string? PreferredLogoStyle { get; set; }
     public string? AlternateLogoStyle { get; set; }
-    //public bool? SeriesPosterArt { get; set; }
-    //public bool? SeriesWsArt { get; set; }
+    public bool? SeriesPosterArt { get; set; }
     public string? SeriesPosterAspect { get; set; }
     public string? ArtworkSize { get; set; }
     public bool? ExcludeCastAndCrew { get; set; }
@@ -23,6 +22,7 @@ public class SDSettingsRequest
 
     [TsProperty(ForceNullable = true)]
     public List<HeadendToView>? HeadendsToView { get; set; }
+
     [TsProperty(ForceNullable = true)]
     public List<StationIdLineup>? SDStationIds { get; set; }
 
@@ -31,8 +31,10 @@ public class SDSettingsRequest
 
     public bool? SeriesImages { get; set; }
     public bool? XmltvAddFillerData { get; set; }
+
     //public string? XmltvFillerProgramDescription { get; set; }
     public int? XmltvFillerProgramLength { get; set; }
+
     public int? MaxSubscribedLineups { get; set; }
     public bool? XmltvIncludeChannelNumbers { get; set; }
     public bool? XmltvExtendedInfoInTitleDescriptions { get; set; }

--- a/src/StreamMaster.Domain/Dto/LogoInfo.cs
+++ b/src/StreamMaster.Domain/Dto/LogoInfo.cs
@@ -36,9 +36,9 @@ public class LogoInfo
         Ext = IsSVG ? ".png" : string.IsNullOrEmpty(ext) ? ".png" : ext;
         Id = cleanedUrl.GenerateFNV1aHash(withExtension: false);
 
-        if (isSchedulesDirect && !url.StartsWithIgnoreCase("image/"))
+        if (isSchedulesDirect && !url.StartsWithIgnoreCase("https://json.schedulesdirect.org/20141201/image/"))
         {
-            url = "image/" + url;
+            url = $"https://json.schedulesdirect.org/20141201/image/{url}";
         }
 
         Url = url;

--- a/src/StreamMaster.SchedulesDirect.Services/SchedulesDirectRepository.cs
+++ b/src/StreamMaster.SchedulesDirect.Services/SchedulesDirectRepository.cs
@@ -326,7 +326,7 @@ public class SchedulesDirectRepository(
 
     public async Task<HttpResponseMessage?> GetSdImageAsync(string uri, CancellationToken cancellationToken)
     {
-        if (!sdSettings.CurrentValue.SDEnabled)
+        if (!sdSettings.CurrentValue.SDEnabled || !sdSettings.CurrentValue.SeriesPosterArt)
         {
             return null;
         }

--- a/src/StreamMaster.WebUI/features/settings/SDSettings.tsx
+++ b/src/StreamMaster.WebUI/features/settings/SDSettings.tsx
@@ -1,94 +1,107 @@
-import { GetMessage } from '@lib/common/intl';
-import { useSettingsContext } from '@lib/context/SettingsProvider';
-import { Fieldset } from 'primereact/fieldset';
-import { SelectItem } from 'primereact/selectitem';
-import React from 'react';
-import { BaseSettings } from './BaseSettings';
-import { GetCheckBoxLine } from './components/GetCheckBoxLine';
-import { GetDropDownLine } from './components/GetDropDownLine';
-import { GetInputNumberLine } from './components/GetInputNumberLine';
-import { GetInputTextLine } from './components/GetInputTextLine';
-import { GetPasswordLine } from './components/GetPasswordLine';
+import { GetMessage } from "@lib/common/intl";
+import { useSettingsContext } from "@lib/context/SettingsProvider";
+import { Fieldset } from "primereact/fieldset";
+import { SelectItem } from "primereact/selectitem";
+import React from "react";
+import { BaseSettings } from "./BaseSettings";
+import { GetCheckBoxLine } from "./components/GetCheckBoxLine";
+import { GetDropDownLine } from "./components/GetDropDownLine";
+import { GetInputNumberLine } from "./components/GetInputNumberLine";
+import { GetInputTextLine } from "./components/GetInputTextLine";
+import { GetPasswordLine } from "./components/GetPasswordLine";
 
 export function SDSettings(): React.ReactElement {
-  const { currentSetting } = useSettingsContext();
+	const { currentSetting } = useSettingsContext();
 
-  const getLogoStyleOptions = (): SelectItem[] => {
-    var options = ['Dark', 'Gray', 'Light', 'White'];
+	const getLogoStyleOptions = (): SelectItem[] => {
+		var options = ["Dark", "Gray", "Light", "White"];
 
-    const test = options.map(
-      (word) =>
-        ({
-          label: word,
-          value: word.toLocaleLowerCase()
-        } as SelectItem)
-    );
+		const test = options.map(
+			(word) =>
+				({
+					label: word,
+					value: word.toLocaleLowerCase(),
+				}) as SelectItem,
+		);
 
-    return test;
-  };
+		return test;
+	};
 
-  const getArtworkSizeOptions = (): SelectItem[] => {
-    var options = ['Sm', 'Md', 'Lg'];
+	const getArtworkSizeOptions = (): SelectItem[] => {
+		var options = ["Sm", "Md", "Lg"];
 
-    const test = options.map(
-      (word) =>
-        ({
-          label: word,
-          value: word.toLocaleLowerCase()
-        } as SelectItem)
-    );
+		const test = options.map(
+			(word) =>
+				({
+					label: word,
+					value: word.toLocaleLowerCase(),
+				}) as SelectItem,
+		);
 
-    return test;
-  };
+		return test;
+	};
 
-  const getArtworkAspectOptions = (): SelectItem[] => {
-    var options = ['2x3', '4x3', '16x9'];
+	const getArtworkAspectOptions = (): SelectItem[] => {
+		var options = ["2x3", "4x3", "16x9"];
 
-    const test = options.map(
-      (word) =>
-        ({
-          label: word,
-          value: word.toLocaleLowerCase()
-        } as SelectItem)
-    );
+		const test = options.map(
+			(word) =>
+				({
+					label: word,
+					value: word.toLocaleLowerCase(),
+				}) as SelectItem,
+		);
 
-    return test;
-  };
+		return test;
+	};
 
-  if (currentSetting === null || currentSetting === undefined) {
-    return (
-      <Fieldset className="mt-4 pt-10" legend={GetMessage('SD')}>
-        <div className="text-center">{GetMessage('loading')}</div>
-      </Fieldset>
-    );
-  }
+	if (currentSetting === null || currentSetting === undefined) {
+		return (
+			<Fieldset className="mt-4 pt-10" legend={GetMessage("SD")}>
+				<div className="text-center">{GetMessage("loading")}</div>
+			</Fieldset>
+		);
+	}
 
-  return (
-    <BaseSettings title="SCHEDULES DIRECT">
-      <>
-        {GetCheckBoxLine({ field: 'SDSettings.SDEnabled' })}
-        {GetInputTextLine({ field: 'SDSettings.SDUserName' })}
-        {GetPasswordLine({ field: 'SDSettings.SDPassword', labelInline: true })}
-        {GetInputNumberLine({ field: 'SDSettings.MaxSubscribedLineups' })}
-        {GetDropDownLine({ field: 'SDSettings.PreferredLogoStyle', options: getLogoStyleOptions() })}
-        {GetDropDownLine({ field: 'SDSettings.AlternateLogoStyle', options: getLogoStyleOptions() })}
-        {GetCheckBoxLine({ field: 'SDSettings.SeriesPosterArt' })}
-        {GetCheckBoxLine({ field: 'SDSettings.SeriesWsArt' })}
-        {GetDropDownLine({ field: 'SDSettings.SeriesPosterAspect', options: getArtworkAspectOptions() })}
-        {GetDropDownLine({ field: 'SDSettings.ArtworkSize', options: getArtworkSizeOptions() })}
-        {/* {GetCheckBoxLine({ field: 'SDSettings.ExcludeCastAndCrew' })} */}
-        {/* {GetCheckBoxLine({ field: 'SDSettings.XmltvIncludeChannelNumbers' })} */}
-        {/* {GetCheckBoxLine({ field: 'SDSettings.AlternateSEFormat' })} */}
-        {/* {GetCheckBoxLine({ field: 'SDSettings.PrefixEpisodeDescription' })}
+	return (
+		<BaseSettings title="SCHEDULES DIRECT">
+			<>
+				{GetCheckBoxLine({ field: "SDSettings.SDEnabled" })}
+				{GetInputTextLine({ field: "SDSettings.SDUserName" })}
+				{GetPasswordLine({ field: "SDSettings.SDPassword", labelInline: true })}
+				{GetInputNumberLine({ field: "SDSettings.MaxSubscribedLineups" })}
+				{GetDropDownLine({
+					field: "SDSettings.PreferredLogoStyle",
+					options: getLogoStyleOptions(),
+				})}
+				{GetDropDownLine({
+					field: "SDSettings.AlternateLogoStyle",
+					options: getLogoStyleOptions(),
+				})}
+				{GetCheckBoxLine({ field: "SDSettings.SeriesPosterArt" })}
+				{GetDropDownLine({
+					field: "SDSettings.SeriesPosterAspect",
+					options: getArtworkAspectOptions(),
+				})}
+				{GetDropDownLine({
+					field: "SDSettings.ArtworkSize",
+					options: getArtworkSizeOptions(),
+				})}
+				{/* {GetCheckBoxLine({ field: 'SDSettings.ExcludeCastAndCrew' })} */}
+				{/* {GetCheckBoxLine({ field: 'SDSettings.XmltvIncludeChannelNumbers' })} */}
+				{/* {GetCheckBoxLine({ field: 'SDSettings.AlternateSEFormat' })} */}
+				{/* {GetCheckBoxLine({ field: 'SDSettings.PrefixEpisodeDescription' })}
         {GetCheckBoxLine({ field: 'SDSettings.PrefixEpisodeTitle' })} */}
-        {/* {GetCheckBoxLine({ field: 'SDSettings.AppendEpisodeDesc' })} */}
-        {GetInputNumberLine({ field: 'SDSettings.SDEPGDays' })}
-        {GetInputNumberLine({ field: 'SDSettings.XmltvFillerProgramLength' })}
-        {GetCheckBoxLine({ field: 'SDSettings.SeasonEventImages' })}
-        {GetCheckBoxLine({ field: 'SDSettings.XmltvAddFillerData' })}
-        {GetCheckBoxLine({ field: 'SDSettings.XmltvExtendedInfoInTitleDescriptions' })}
-        {GetCheckBoxLine({ field: 'SDSettings.XmltvSingleImage' })}
-      </>
-    </BaseSettings>
-  );
+				{/* {GetCheckBoxLine({ field: 'SDSettings.AppendEpisodeDesc' })} */}
+				{GetInputNumberLine({ field: "SDSettings.SDEPGDays" })}
+				{GetInputNumberLine({ field: "SDSettings.XmltvFillerProgramLength" })}
+				{GetCheckBoxLine({ field: "SDSettings.SeasonEventImages" })}
+				{GetCheckBoxLine({ field: "SDSettings.XmltvAddFillerData" })}
+				{GetCheckBoxLine({
+					field: "SDSettings.XmltvExtendedInfoInTitleDescriptions",
+				})}
+				{GetCheckBoxLine({ field: "SDSettings.XmltvSingleImage" })}
+			</>
+		</BaseSettings>
+	);
 }

--- a/src/StreamMaster.WebUI/lib/smAPI/smapiTypes.ts
+++ b/src/StreamMaster.WebUI/lib/smAPI/smapiTypes.ts
@@ -483,6 +483,7 @@ export interface SDSettings
 	SDUserName: string;
 	SeasonImages: boolean;
 	SeriesImages: boolean;
+	SeriesPosterArt: boolean;
 	SeriesPosterAspect: string;
 	SportsImages: boolean;
 	TokenErrorTimestamp: any;
@@ -514,6 +515,7 @@ export interface SDSettingsRequest
 	SDUserName?: string;
 	SeasonImages?: boolean;
 	SeriesImages?: boolean;
+	SeriesPosterArt?: boolean;
 	SeriesPosterAspect?: string;
 	SportsImages?: boolean;
 	XmltvAddFillerData?: boolean;
@@ -756,30 +758,6 @@ export interface MoveToNextStreamRequest
 {
 	SMChannelId: number;
 }
-export interface GetStreamGroupSMChannelsRequest
-{
-	StreamGroupId: number;
-}
-export interface AddSMChannelsToStreamGroupByParametersRequest
-{
-	Parameters: QueryStringParameters;
-	StreamGroupId: number;
-}
-export interface AddSMChannelsToStreamGroupRequest
-{
-	SMChannelIds: number[];
-	StreamGroupId: number;
-}
-export interface AddSMChannelToStreamGroupRequest
-{
-	SMChannelId: number;
-	StreamGroupId: number;
-}
-export interface RemoveSMChannelFromStreamGroupRequest
-{
-	SMChannelId: number;
-	StreamGroupId: number;
-}
 export interface SGFS
 {
 	Name: string;
@@ -843,6 +821,30 @@ export interface UpdateStreamGroupRequest
 	DeviceID?: string;
 	GroupKey?: string;
 	NewName?: string;
+	StreamGroupId: number;
+}
+export interface GetStreamGroupSMChannelsRequest
+{
+	StreamGroupId: number;
+}
+export interface AddSMChannelsToStreamGroupByParametersRequest
+{
+	Parameters: QueryStringParameters;
+	StreamGroupId: number;
+}
+export interface AddSMChannelsToStreamGroupRequest
+{
+	SMChannelIds: number[];
+	StreamGroupId: number;
+}
+export interface AddSMChannelToStreamGroupRequest
+{
+	SMChannelId: number;
+	StreamGroupId: number;
+}
+export interface RemoveSMChannelFromStreamGroupRequest
+{
+	SMChannelId: number;
 	StreamGroupId: number;
 }
 export interface GetChannelMetricsRequest
@@ -955,25 +957,6 @@ export interface SendSuccessRequest
 {
 	Detail: string;
 	Summary: string;
-}
-export interface GetSMChannelStreamsRequest
-{
-	SMChannelId: number;
-}
-export interface AddSMStreamToSMChannelRequest
-{
-	Rank?: number;
-	SMChannelId: number;
-	SMStreamId: string;
-}
-export interface RemoveSMStreamFromSMChannelRequest
-{
-	SMChannelId: number;
-	SMStreamId: string;
-}
-export interface SetSMStreamRanksRequest
-{
-	Requests: SMChannelStreamRankRequest[];
 }
 export interface GetPagedSMChannelsRequest
 {
@@ -1157,6 +1140,25 @@ export interface UpdateSMChannelRequest
 	StationId?: string;
 	TimeShift?: number;
 	VideoStreamHandler?: VideoStreamHandlers;
+}
+export interface GetSMChannelStreamsRequest
+{
+	SMChannelId: number;
+}
+export interface AddSMStreamToSMChannelRequest
+{
+	Rank?: number;
+	SMChannelId: number;
+	SMStreamId: string;
+}
+export interface RemoveSMStreamFromSMChannelRequest
+{
+	SMChannelId: number;
+	SMStreamId: string;
+}
+export interface SetSMStreamRanksRequest
+{
+	Requests: SMChannelStreamRankRequest[];
 }
 export interface GetSMChannelChannelsRequest
 {
@@ -1455,6 +1457,12 @@ export interface SetTestTaskRequest
 {
 	DelayInSeconds: number;
 }
+export interface GetEPGColorsRequest
+{
+}
+export interface EPGSyncRequest
+{
+}
 export interface GetEPGFileNamesRequest
 {
 }
@@ -1514,12 +1522,6 @@ export interface UpdateEPGFileRequest
 	Name?: string;
 	TimeShift?: number;
 	Url?: string;
-}
-export interface GetEPGColorsRequest
-{
-}
-export interface EPGSyncRequest
-{
 }
 export interface GetCustomPlayListRequest
 {


### PR DESCRIPTION
## Description

The settings toggles for `ENABLE SERIES POSTER ART` and `ENABLE SERIES WIDE SCREEN ART` were exposed on the UI, but all the back-end logic had been commented out. This change now re-enabled just the `ENABLE SERIES POSTER ART` option, as the `ENABLE SERIES WIDE SCREEN ART` can probably be controlled by `SERIES POSTER ASPECT RATIO`(?).

However, this setting was unused currently. So StreamMaster by default was attempting to download the poster/images. The problem was that the URL was not being built correctly, meaning that the content was not downloaded.

### Issues (Fixed or Closed)

- Fixes https://github.com/carlreid/StreamMaster/issues/101

## Type of Change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

Toggle on `ENABLE SERIES POSTER ART`. Should now see program images appearing in EPG (_might need to restart StreamMaster to force a sync_) sourced from `config/Cache/ProgramLogos`

## Visual Changes

<!-- If applicable, add screenshots or videos to show visual changes -->
- [ ] Screenshots/videos attached

## Dependencies

<!-- List any dependencies that were added/removed/updated -->
- [ ] New dependencies added
- [ ] System requirements changed

## Checklist

- [x] I have followed the [Conventional Commits](https://www.conventionalcommits.org/) naming convention
- [x] My branch is up to date with the `main` branch (rebased)
- [x] My code follows the style guidelines and existing patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented complex logic
- [ ] I have added tests (if applicable)
- [x] All tests are passing
- [ ] I have updated documentation as needed
